### PR TITLE
Add SSL option for database setup

### DIFF
--- a/scripts/start-with-runtime-config.mjs
+++ b/scripts/start-with-runtime-config.mjs
@@ -13,6 +13,9 @@ if (existsSync(configPath)) {
     if (config?.databaseUrl && !process.env.DATABASE_URL) {
       process.env.DATABASE_URL = String(config.databaseUrl);
     }
+    if (config?.databaseSsl !== undefined && !process.env.DATABASE_SSL) {
+      process.env.DATABASE_SSL = config.databaseSsl ? "true" : "false";
+    }
     if (config?.nextAuthSecret && !process.env.NEXTAUTH_SECRET) {
       process.env.NEXTAUTH_SECRET = String(config.nextAuthSecret);
     }

--- a/src/app/api/setup/complete/handler.test.ts
+++ b/src/app/api/setup/complete/handler.test.ts
@@ -48,6 +48,7 @@ describe("setup complete handler", () => {
         dbUser: "desktop",
         dbPassword: "desktop",
         dbName: "customdb",
+        dbSsl: true,
         email: "admin@test.dev",
         password: "Password1!",
       }),
@@ -61,7 +62,9 @@ describe("setup complete handler", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(received?.databaseUrl).toBe("postgresql://desktop:desktop@db:5432/customdb");
+    expect(received?.databaseUrl).toBe(
+      "postgresql://desktop:desktop@db:5432/customdb?sslmode=require&sslaccept=accept_invalid_certs"
+    );
   });
 
   it("allows database override when db is unavailable", async () => {

--- a/src/app/api/setup/complete/handler.ts
+++ b/src/app/api/setup/complete/handler.ts
@@ -29,12 +29,14 @@ export async function handleSetupComplete(
     body: maskedBody,
   });
   const rawDatabaseUrl = String(body?.databaseUrl ?? "");
+  const dbSsl = Boolean(body?.dbSsl);
   const builtDatabaseUrl = buildDatabaseUrl({
     host: String(body?.dbHost ?? ""),
     port: String(body?.dbPort ?? ""),
     user: String(body?.dbUser ?? ""),
     password: String(body?.dbPassword ?? ""),
     database: String(body?.dbName ?? ""),
+    ssl: dbSsl,
   });
   const databaseUrl = rawDatabaseUrl || (builtDatabaseUrl.ok ? builtDatabaseUrl.value : "");
   const status = await deps.getSetupStatus();
@@ -45,6 +47,7 @@ export async function handleSetupComplete(
       email: String(body?.email ?? ""),
       password: String(body?.password ?? ""),
       allowDatabaseUrlOverride,
+      databaseSsl: dbSsl,
     },
     deps.createDefaultSetupDeps()
   );

--- a/src/app/setup/SetupWizard.tsx
+++ b/src/app/setup/SetupWizard.tsx
@@ -27,6 +27,7 @@ type LayoutProps = {
   dbUser: string;
   dbPassword: string;
   dbName: string;
+  dbSsl: boolean;
   loading: boolean;
   error: string | null;
   success: boolean;
@@ -37,6 +38,7 @@ type LayoutProps = {
   onChangeDbUser: (value: string) => void;
   onChangeDbPassword: (value: string) => void;
   onChangeDbName: (value: string) => void;
+  onChangeDbSsl: (value: boolean) => void;
   onSubmit: (event: React.FormEvent) => void;
   onNext: () => void;
   onBack: () => void;
@@ -53,6 +55,7 @@ export function SetupWizardLayout({
   dbUser,
   dbPassword,
   dbName,
+  dbSsl,
   loading,
   error,
   success,
@@ -63,6 +66,7 @@ export function SetupWizardLayout({
   onChangeDbUser,
   onChangeDbPassword,
   onChangeDbName,
+  onChangeDbSsl,
   onSubmit,
   onNext,
   onBack,
@@ -145,6 +149,14 @@ export function SetupWizardLayout({
                       required
                     />
                   </label>
+                  <label className="setup-field setup-field-inline">
+                    <span>SSL (самоподписанный)</span>
+                    <input
+                      type="checkbox"
+                      checked={dbSsl}
+                      onChange={(event) => onChangeDbSsl(event.target.checked)}
+                    />
+                  </label>
                 </div>
               ) : (
                 <>
@@ -219,6 +231,7 @@ export default function SetupWizard({ initialStatus }: WizardProps) {
   const [dbUser, setDbUser] = useState("");
   const [dbPassword, setDbPassword] = useState("");
   const [dbName, setDbName] = useState("");
+  const [dbSsl, setDbSsl] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -232,10 +245,11 @@ export default function SetupWizard({ initialStatus }: WizardProps) {
       dbUser,
       dbPassword,
       dbName,
+      dbSsl,
       email,
       password,
     }),
-    [dbHost, dbPort, dbUser, dbPassword, dbName, email, password]
+    [dbHost, dbPort, dbUser, dbPassword, dbName, dbSsl, email, password]
   );
 
   const onNext = () => {
@@ -284,6 +298,7 @@ export default function SetupWizard({ initialStatus }: WizardProps) {
       dbUser={dbUser}
       dbPassword={dbPassword}
       dbName={dbName}
+      dbSsl={dbSsl}
       loading={loading}
       error={error}
       success={success}
@@ -294,6 +309,7 @@ export default function SetupWizard({ initialStatus }: WizardProps) {
       onChangeDbUser={setDbUser}
       onChangeDbPassword={setDbPassword}
       onChangeDbName={setDbName}
+      onChangeDbSsl={setDbSsl}
       onSubmit={onSubmit}
       onNext={onNext}
       onBack={onBack}

--- a/src/app/setup/__tests__/setup-wizard-layout.test.tsx
+++ b/src/app/setup/__tests__/setup-wizard-layout.test.tsx
@@ -12,6 +12,7 @@ const baseProps = {
   dbUser: "",
   dbPassword: "",
   dbName: "",
+  dbSsl: false,
   loading: false,
   error: null as string | null,
   success: false,
@@ -22,6 +23,7 @@ const baseProps = {
   onChangeDbUser: () => undefined,
   onChangeDbPassword: () => undefined,
   onChangeDbName: () => undefined,
+  onChangeDbSsl: () => undefined,
   onSubmit: () => undefined,
   onNext: () => undefined,
   onBack: () => undefined,
@@ -36,6 +38,7 @@ describe("setup wizard layout", () => {
     expect(html).toContain("User");
     expect(html).toContain("Password");
     expect(html).toContain("Database");
+    expect(html).toContain("SSL");
   });
 
   it("omits database name and secrets step", () => {

--- a/src/lib/__tests__/build-database-url.test.ts
+++ b/src/lib/__tests__/build-database-url.test.ts
@@ -9,10 +9,28 @@ describe("buildDatabaseUrl", () => {
       user: "desk",
       password: "pa ss",
       database: "desktop",
+      ssl: false,
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value).toBe("postgresql://desk:pa%20ss@db:5432/desktop");
+    }
+  });
+
+  it("appends ssl options when ssl is enabled", () => {
+    const result = buildDatabaseUrl({
+      host: "db",
+      port: "5432",
+      user: "desk",
+      password: "pa ss",
+      database: "desktop",
+      ssl: true,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(
+        "postgresql://desk:pa%20ss@db:5432/desktop?sslmode=require&sslaccept=accept_invalid_certs"
+      );
     }
   });
 
@@ -23,6 +41,7 @@ describe("buildDatabaseUrl", () => {
       user: "",
       password: "",
       database: "",
+      ssl: false,
     });
     expect(result.ok).toBe(false);
   });

--- a/src/lib/__tests__/runtime-config.test.ts
+++ b/src/lib/__tests__/runtime-config.test.ts
@@ -11,6 +11,7 @@ describe("runtime config", () => {
     vi.stubEnv("DATABASE_URL", "");
     const config = {
       databaseUrl: "postgresql://user:pass@host/db",
+      databaseSsl: true,
       nextAuthSecret: "secret1234567890abcd",
       keysEncryptionSecret: "secret1234567890abcd",
     };
@@ -19,13 +20,16 @@ describe("runtime config", () => {
     });
     expect(load.databaseUrl).toBe(config.databaseUrl);
     expect(process.env.DATABASE_URL).toBe(config.databaseUrl);
+    expect(process.env.DATABASE_SSL).toBe("true");
   });
 
   it("falls back to env vars when config file is missing", () => {
     vi.stubEnv("DATABASE_URL", "postgresql://user:pass@db:5432/desktop");
+    vi.stubEnv("DATABASE_SSL", "true");
     vi.stubEnv("NEXTAUTH_SECRET", "secret1234567890abcd");
     vi.stubEnv("KEYS_ENCRYPTION_SECRET", "secret1234567890abcd");
     const load = loadRuntimeConfig({ mockConfig: null });
     expect(load?.databaseUrl).toBe("postgresql://user:pass@db:5432/desktop");
+    expect(load?.databaseSsl).toBe(true);
   });
 });

--- a/src/lib/__tests__/setup-completion.test.ts
+++ b/src/lib/__tests__/setup-completion.test.ts
@@ -29,11 +29,18 @@ describe("setup completion", () => {
   it("writes config and creates admin when fresh", async () => {
     const deps = baseDeps();
     const result = await completeSetup(
-      { databaseUrl: "postgres://db", email: "admin@test.dev", password: "Password1!" },
+      {
+        databaseUrl: "postgres://db",
+        databaseSsl: true,
+        email: "admin@test.dev",
+        password: "Password1!",
+      },
       deps
     );
     expect(result.status).toBe("ok");
-    expect(deps.writeConfig).toHaveBeenCalledOnce();
+    expect(deps.writeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ databaseSsl: true })
+    );
     expect(deps.applyConfig).toHaveBeenCalledOnce();
     expect(deps.runMigrations).toHaveBeenCalledOnce();
     expect(deps.createAdmin).toHaveBeenCalledOnce();
@@ -42,7 +49,12 @@ describe("setup completion", () => {
   it("does not attempt to create databases automatically", async () => {
     const deps = baseDeps();
     const result = await completeSetup(
-      { databaseUrl: "postgres://db", email: "admin@test.dev", password: "Password1!" },
+      {
+        databaseUrl: "postgres://db",
+        databaseSsl: true,
+        email: "admin@test.dev",
+        password: "Password1!",
+      },
       deps
     );
     expect(result.status).toBe("ok");
@@ -53,11 +65,17 @@ describe("setup completion", () => {
     const deps = baseDeps();
     deps.loadConfig = () => ({
       databaseUrl: "postgres://existing",
+      databaseSsl: false,
       nextAuthSecret: "secret-aaaaaaaaaaaaaaa",
       keysEncryptionSecret: "secret-bbbbbbbbbbbbbbb",
     });
     const result = await completeSetup(
-      { databaseUrl: "postgres://ignored", email: "admin@test.dev", password: "Password1!" },
+      {
+        databaseUrl: "postgres://ignored",
+        databaseSsl: true,
+        email: "admin@test.dev",
+        password: "Password1!",
+      },
       deps
     );
     expect(result.status).toBe("ok");
@@ -70,6 +88,7 @@ describe("setup completion", () => {
     const applyConfig = vi.fn();
     deps.loadConfig = () => ({
       databaseUrl: "postgres://existing",
+      databaseSsl: false,
       nextAuthSecret: "secret-aaaaaaaaaaaaaaa",
       keysEncryptionSecret: "secret-bbbbbbbbbbbbbbb",
     });
@@ -79,6 +98,7 @@ describe("setup completion", () => {
     const result = await completeSetup(
       {
         databaseUrl: "postgres://new",
+        databaseSsl: true,
         email: "admin@test.dev",
         password: "Password1!",
         allowDatabaseUrlOverride: true,
@@ -89,11 +109,13 @@ describe("setup completion", () => {
     expect(result.status).toBe("ok");
     expect(writeConfig).toHaveBeenCalledWith({
       databaseUrl: "postgres://new",
+      databaseSsl: true,
       nextAuthSecret: "secret-aaaaaaaaaaaaaaa",
       keysEncryptionSecret: "secret-bbbbbbbbbbbbbbb",
     });
     expect(applyConfig).toHaveBeenCalledWith({
       databaseUrl: "postgres://new",
+      databaseSsl: true,
       nextAuthSecret: "secret-aaaaaaaaaaaaaaa",
       keysEncryptionSecret: "secret-bbbbbbbbbbbbbbb",
     });
@@ -103,6 +125,7 @@ describe("setup completion", () => {
     const deps = baseDeps();
     deps.loadConfig = () => ({
       databaseUrl: "postgres://existing",
+      databaseSsl: false,
       nextAuthSecret: "secret-aaaaaaaaaaaaaaa",
       keysEncryptionSecret: "secret-bbbbbbbbbbbbbbb",
     });
@@ -110,6 +133,7 @@ describe("setup completion", () => {
     const result = await completeSetup(
       {
         databaseUrl: "mysql://bad",
+        databaseSsl: true,
         email: "admin@test.dev",
         password: "Password1!",
         allowDatabaseUrlOverride: true,
@@ -124,7 +148,12 @@ describe("setup completion", () => {
     const deps = baseDeps();
     deps.getUserCount = vi.fn().mockResolvedValue(2);
     const result = await completeSetup(
-      { databaseUrl: "postgres://db", email: "admin@test.dev", password: "Password1!" },
+      {
+        databaseUrl: "postgres://db",
+        databaseSsl: true,
+        email: "admin@test.dev",
+        password: "Password1!",
+      },
       deps
     );
     expect(result.status).toBe("alreadySetup");

--- a/src/lib/buildDatabaseUrl.ts
+++ b/src/lib/buildDatabaseUrl.ts
@@ -4,6 +4,7 @@ type DbParts = {
   user: string;
   password: string;
   database: string;
+  ssl: boolean;
 };
 
 type Result = { ok: true; value: string } | { ok: false; error: string };
@@ -19,8 +20,10 @@ export function buildDatabaseUrl(input: DbParts): Result {
   }
   const encodedUser = encodeURIComponent(user);
   const encodedPassword = encodeURIComponent(password);
+  const baseUrl = `postgresql://${encodedUser}:${encodedPassword}@${host}:${port}/${database}`;
+  const sslSuffix = input.ssl ? "?sslmode=require&sslaccept=accept_invalid_certs" : "";
   return {
     ok: true,
-    value: `postgresql://${encodedUser}:${encodedPassword}@${host}:${port}/${database}`,
+    value: `${baseUrl}${sslSuffix}`,
   };
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -14,7 +14,13 @@ export function getPrisma() {
   }
 
   const databaseUrl = getDatabaseUrl();
-  const pool = globalForPrisma.pgPool ?? new Pool({ connectionString: databaseUrl });
+  const useSsl = process.env.DATABASE_SSL === "true";
+  const pool =
+    globalForPrisma.pgPool ??
+    new Pool({
+      connectionString: databaseUrl,
+      ssl: useSsl ? { rejectUnauthorized: false } : undefined,
+    });
   const adapter = new PrismaPg(pool);
   const client = new PrismaClient({
     adapter,

--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 
 export type RuntimeConfig = {
   databaseUrl: string;
+  databaseSsl?: boolean;
   nextAuthSecret: string;
   keysEncryptionSecret: string;
 };
@@ -22,12 +23,18 @@ function readConfigFile(path: string): RuntimeConfig | null {
 
 function buildEnvConfig(): RuntimeConfig | null {
   const databaseUrl = process.env.DATABASE_URL?.trim() || "";
+  const databaseSsl = process.env.DATABASE_SSL?.trim() || "";
   const nextAuthSecret = process.env.NEXTAUTH_SECRET?.trim() || "";
   const keysEncryptionSecret = process.env.KEYS_ENCRYPTION_SECRET?.trim() || "";
   if (!databaseUrl || !nextAuthSecret || !keysEncryptionSecret) {
     return null;
   }
-  return { databaseUrl, nextAuthSecret, keysEncryptionSecret };
+  return {
+    databaseUrl,
+    databaseSsl: databaseSsl ? databaseSsl === "true" : undefined,
+    nextAuthSecret,
+    keysEncryptionSecret,
+  };
 }
 
 export function loadRuntimeConfig(options?: { mockConfig?: RuntimeConfig | null }) {
@@ -37,6 +44,9 @@ export function loadRuntimeConfig(options?: { mockConfig?: RuntimeConfig | null 
     return null;
   }
   process.env.DATABASE_URL ||= resolved.databaseUrl;
+  if (resolved.databaseSsl !== undefined) {
+    process.env.DATABASE_SSL ||= resolved.databaseSsl ? "true" : "false";
+  }
   process.env.NEXTAUTH_SECRET ||= resolved.nextAuthSecret;
   process.env.KEYS_ENCRYPTION_SECRET ||= resolved.keysEncryptionSecret;
   return resolved;

--- a/src/lib/setupCompletion.ts
+++ b/src/lib/setupCompletion.ts
@@ -13,6 +13,7 @@ import { validateEmail, validatePassword } from "./validation";
 
 export type SetupCompletionInput = {
   databaseUrl?: string;
+  databaseSsl?: boolean;
   email: string;
   password: string;
   allowDatabaseUrlOverride?: boolean;
@@ -54,6 +55,7 @@ export async function completeSetup(
   }
 
   let config = deps.loadConfig();
+  const databaseSsl = Boolean(input.databaseSsl);
   if (!config) {
     const dbCheck = deps.validateDatabaseUrl(input.databaseUrl ?? "");
     if (!dbCheck.ok) {
@@ -61,6 +63,7 @@ export async function completeSetup(
     }
     config = {
       databaseUrl: input.databaseUrl ?? "",
+      databaseSsl,
       nextAuthSecret: deps.generateSecret(),
       keysEncryptionSecret: deps.generateSecret(),
     };
@@ -73,6 +76,7 @@ export async function completeSetup(
     config = {
       ...config,
       databaseUrl: input.databaseUrl,
+      databaseSsl,
     };
     await deps.writeConfig(config);
   }
@@ -108,6 +112,9 @@ export function createDefaultSetupDeps(): SetupCompletionDeps {
     },
     applyConfig: (config) => {
       process.env.DATABASE_URL = config.databaseUrl;
+      if (config.databaseSsl !== undefined) {
+        process.env.DATABASE_SSL = config.databaseSsl ? "true" : "false";
+      }
       process.env.NEXTAUTH_SECRET = config.nextAuthSecret;
       process.env.KEYS_ENCRYPTION_SECRET = config.keysEncryptionSecret;
     },


### PR DESCRIPTION
## Summary
- Add SSL toggle in setup wizard for self-signed Postgres
- Persist SSL choice in runtime config and apply to pg pool
- Extend database URL builder to include ssl params when enabled

## Test Plan
- [x] npm test src/app/setup/__tests__/setup-wizard-layout.test.tsx
- [x] npm test src/lib/__tests__/build-database-url.test.ts
- [x] npm test src/app/api/setup/complete/handler.test.ts
- [x] npm test src/lib/__tests__/setup-completion.test.ts
- [x] npm test src/lib/__tests__/runtime-config.test.ts