### PR TITLE
Auto-enable SSL during setup for self-signed certs

### DIFF
--- a/src/app/api/setup/complete/handler.ts
+++ b/src/app/api/setup/complete/handler.ts
@@ -39,7 +39,7 @@ export async function handleSetupComplete(
     ssl: dbSsl,
   });
   const databaseUrl = rawDatabaseUrl || (builtDatabaseUrl.ok ? builtDatabaseUrl.value : "");
-  const status = await deps.getSetupStatus();
+  const status = await deps.getSetupStatus({ allowAutoSslFix: true });
   const allowDatabaseUrlOverride = status === "dbUnavailable";
   const result = await deps.completeSetup(
     {

--- a/src/app/api/setup/status/route.ts
+++ b/src/app/api/setup/status/route.ts
@@ -2,6 +2,6 @@ import { NextResponse } from "next/server";
 import { getSetupStatus } from "@/lib/setupStatus";
 
 export async function GET() {
-  const status = await getSetupStatus();
+  const status = await getSetupStatus({ allowAutoSslFix: true });
   return NextResponse.json({ status });
 }

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -5,7 +5,7 @@ import { getSetupStatus } from "@/lib/setupStatus";
 import SetupWizard from "./SetupWizard";
 
 export default async function SetupPage() {
-  const status = await getSetupStatus();
+  const status = await getSetupStatus({ allowAutoSslFix: true });
   if (status === "ready") {
     redirect("/");
   }

--- a/src/lib/__tests__/setup-status.test.ts
+++ b/src/lib/__tests__/setup-status.test.ts
@@ -11,6 +11,7 @@ import { getSetupStatus } from "../setupStatus";
 
 const mockConfig: RuntimeConfig = {
   databaseUrl: "postgresql://user:pass@localhost:5432/desktop",
+  databaseSsl: false,
   nextAuthSecret: "secret",
   keysEncryptionSecret: "keys",
 };
@@ -40,5 +41,44 @@ describe("setup status", () => {
   it("returns dbUnavailable when migrations fail", async () => {
     ensureDatabaseReady.mockRejectedValue(new Error("boom"));
     expect(await getSetupStatus({ mockConfig })).toBe("dbUnavailable");
+  });
+
+  it("auto-enables ssl during setup when self-signed error occurs", async () => {
+    const count = vi.fn().mockResolvedValue(0);
+    getPrisma.mockReturnValue({ user: { count } });
+    ensureDatabaseReady
+      .mockRejectedValueOnce(new Error("self-signed certificate"))
+      .mockResolvedValueOnce(undefined);
+    const saveConfig = vi.fn().mockResolvedValue(undefined);
+
+    const status = await getSetupStatus({
+      mockConfig,
+      allowAutoSslFix: true,
+      saveConfig,
+    });
+
+    expect(status).toBe("needsAdmin");
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseSsl: true,
+      })
+    );
+    expect(ensureDatabaseReady).toHaveBeenCalledTimes(2);
+    const secondCallUrl = ensureDatabaseReady.mock.calls[1]?.[0] as string;
+    expect(secondCallUrl).toContain("sslmode=require");
+    expect(secondCallUrl).toContain("sslaccept=accept_invalid_certs");
+  });
+
+  it("does not auto-enable ssl when not in setup flow", async () => {
+    ensureDatabaseReady.mockRejectedValue(new Error("self signed certificate"));
+    const saveConfig = vi.fn().mockResolvedValue(undefined);
+
+    const status = await getSetupStatus({
+      mockConfig,
+      saveConfig,
+    });
+
+    expect(status).toBe("dbUnavailable");
+    expect(saveConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/setupStatus.ts
+++ b/src/lib/setupStatus.ts
@@ -1,9 +1,49 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import { ensureDatabaseReady } from "./databaseReady";
-import { loadRuntimeConfig, RuntimeConfig } from "./runtimeConfig";
+import { loadRuntimeConfig, resolveConfigPath, RuntimeConfig } from "./runtimeConfig";
 
 export type SetupStatus = "needsSetup" | "needsAdmin" | "ready" | "dbUnavailable";
 
-export async function getSetupStatus(options?: { mockConfig?: RuntimeConfig | null }) {
+type SetupStatusOptions = {
+  mockConfig?: RuntimeConfig | null;
+  allowAutoSslFix?: boolean;
+  saveConfig?: (config: RuntimeConfig) => Promise<void>;
+};
+
+function isSelfSignedError(error: unknown) {
+  if (!error) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  if (/self[-\s]?signed certificate/i.test(message)) {
+    return true;
+  }
+  const code = (error as { code?: string }).code;
+  return code === "DEPTH_ZERO_SELF_SIGNED_CERT" || code === "SELF_SIGNED_CERT_IN_CHAIN";
+}
+
+function withSslParams(databaseUrl: string) {
+  try {
+    const url = new URL(databaseUrl);
+    if (!url.searchParams.get("sslmode")) {
+      url.searchParams.set("sslmode", "require");
+    }
+    if (!url.searchParams.get("sslaccept")) {
+      url.searchParams.set("sslaccept", "accept_invalid_certs");
+    }
+    return url.toString();
+  } catch {
+    return databaseUrl;
+  }
+}
+
+async function defaultSaveConfig(config: RuntimeConfig) {
+  const path = resolveConfigPath();
+  await mkdir(path.replace("/config.json", ""), { recursive: true });
+  await writeFile(path, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+export async function getSetupStatus(options?: SetupStatusOptions) {
   const config = loadRuntimeConfig(
     options?.mockConfig !== undefined ? { mockConfig: options.mockConfig } : undefined
   );
@@ -16,7 +56,33 @@ export async function getSetupStatus(options?: { mockConfig?: RuntimeConfig | nu
     const prisma = getPrisma();
     const count = await prisma.user.count();
     return count === 0 ? "needsAdmin" : "ready";
-  } catch {
+  } catch (error) {
+    if (options?.allowAutoSslFix && isSelfSignedError(error)) {
+      const updatedUrl = withSslParams(config.databaseUrl);
+      const updatedConfig = {
+        ...config,
+        databaseUrl: updatedUrl,
+        databaseSsl: true,
+      };
+      if (
+        updatedConfig.databaseSsl !== config.databaseSsl ||
+        updatedConfig.databaseUrl !== config.databaseUrl
+      ) {
+        const saveConfig = options.saveConfig ?? defaultSaveConfig;
+        await saveConfig(updatedConfig);
+        process.env.DATABASE_URL = updatedConfig.databaseUrl;
+        process.env.DATABASE_SSL = "true";
+        try {
+          await ensureDatabaseReady(updatedConfig.databaseUrl);
+          const { getPrisma } = await import("./db");
+          const prisma = getPrisma();
+          const count = await prisma.user.count();
+          return count === 0 ? "needsAdmin" : "ready";
+        } catch {
+          return "dbUnavailable";
+        }
+      }
+    }
     return "dbUnavailable";
   }
 }


### PR DESCRIPTION
## Summary
- Auto-enable SSL during setup when self-signed certificate error occurs
- Derive SSL config from database URL/env
- Add SSL hint text in setup wizard

## Test Plan
- [x] npm test src/lib/__tests__/setup-status.test.ts
- [x] npm test src/app/setup/__tests__/setup-wizard-layout.test.tsx