### PR TITLE
Setup onboarding + NEXTAUTH_URL persistence

### DIFF
--- a/scripts/start-with-runtime-config.mjs
+++ b/scripts/start-with-runtime-config.mjs
@@ -16,6 +16,9 @@ if (existsSync(configPath)) {
     if (config?.databaseSsl !== undefined && !process.env.DATABASE_SSL) {
       process.env.DATABASE_SSL = config.databaseSsl ? "true" : "false";
     }
+    if (config?.nextAuthUrl && !process.env.NEXTAUTH_URL) {
+      process.env.NEXTAUTH_URL = String(config.nextAuthUrl);
+    }
     if (config?.nextAuthSecret && !process.env.NEXTAUTH_SECRET) {
       process.env.NEXTAUTH_SECRET = String(config.nextAuthSecret);
     }

--- a/src/app/api/setup/admin/provision/route.ts
+++ b/src/app/api/setup/admin/provision/route.ts
@@ -53,9 +53,11 @@ export async function POST(request: Request) {
     );
   }
 
+  const nextAuthUrl = request.headers.get("origin") || undefined;
   const config = {
     databaseUrl: dbUrlResult.value,
     databaseSsl: app.ssl,
+    nextAuthUrl,
     nextAuthSecret: randomBytes(32).toString("hex"),
     keysEncryptionSecret: randomBytes(32).toString("hex"),
   };

--- a/src/lib/__tests__/runtime-config.test.ts
+++ b/src/lib/__tests__/runtime-config.test.ts
@@ -12,6 +12,7 @@ describe("runtime config", () => {
     const config = {
       databaseUrl: "postgresql://user:pass@host/db",
       databaseSsl: true,
+      nextAuthUrl: "http://10.10.1.236:3000",
       nextAuthSecret: "secret1234567890abcd",
       keysEncryptionSecret: "secret1234567890abcd",
     };
@@ -21,15 +22,18 @@ describe("runtime config", () => {
     expect(load.databaseUrl).toBe(config.databaseUrl);
     expect(process.env.DATABASE_URL).toBe(config.databaseUrl);
     expect(process.env.DATABASE_SSL).toBe("true");
+    expect(process.env.NEXTAUTH_URL).toBe("http://10.10.1.236:3000");
   });
 
   it("falls back to env vars when config file is missing", () => {
     vi.stubEnv("DATABASE_URL", "postgresql://user:pass@db:5432/desktop");
     vi.stubEnv("DATABASE_SSL", "true");
     vi.stubEnv("NEXTAUTH_SECRET", "secret1234567890abcd");
+    vi.stubEnv("NEXTAUTH_URL", "http://10.10.1.236:3000");
     vi.stubEnv("KEYS_ENCRYPTION_SECRET", "secret1234567890abcd");
     const load = loadRuntimeConfig({ mockConfig: null });
     expect(load?.databaseUrl).toBe("postgresql://user:pass@db:5432/desktop");
     expect(load?.databaseSsl).toBe(true);
+    expect(load?.nextAuthUrl).toBe("http://10.10.1.236:3000");
   });
 });

--- a/src/lib/runtimeConfig.ts
+++ b/src/lib/runtimeConfig.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 export type RuntimeConfig = {
   databaseUrl: string;
   databaseSsl?: boolean;
+  nextAuthUrl?: string;
   nextAuthSecret: string;
   keysEncryptionSecret: string;
 };
@@ -24,6 +25,7 @@ function readConfigFile(path: string): RuntimeConfig | null {
 function buildEnvConfig(): RuntimeConfig | null {
   const databaseUrl = process.env.DATABASE_URL?.trim() || "";
   const databaseSsl = process.env.DATABASE_SSL?.trim() || "";
+  const nextAuthUrl = process.env.NEXTAUTH_URL?.trim() || "";
   const nextAuthSecret = process.env.NEXTAUTH_SECRET?.trim() || "";
   const keysEncryptionSecret = process.env.KEYS_ENCRYPTION_SECRET?.trim() || "";
   if (!databaseUrl || !nextAuthSecret || !keysEncryptionSecret) {
@@ -32,6 +34,7 @@ function buildEnvConfig(): RuntimeConfig | null {
   return {
     databaseUrl,
     databaseSsl: databaseSsl ? databaseSsl === "true" : undefined,
+    nextAuthUrl: nextAuthUrl || undefined,
     nextAuthSecret,
     keysEncryptionSecret,
   };
@@ -46,6 +49,9 @@ export function loadRuntimeConfig(options?: { mockConfig?: RuntimeConfig | null 
   process.env.DATABASE_URL ||= resolved.databaseUrl;
   if (resolved.databaseSsl !== undefined) {
     process.env.DATABASE_SSL ||= resolved.databaseSsl ? "true" : "false";
+  }
+  if (resolved.nextAuthUrl) {
+    process.env.NEXTAUTH_URL ||= resolved.nextAuthUrl;
   }
   process.env.NEXTAUTH_SECRET ||= resolved.nextAuthSecret;
   process.env.KEYS_ENCRYPTION_SECRET ||= resolved.keysEncryptionSecret;


### PR DESCRIPTION
## Summary\n- multi-step setup flow (step-1..4) with admin DB provisioning\n- provision app DB/user without storing admin creds\n- persist NEXTAUTH_URL from setup origin\n\n## Testing\n- npm test\n