### PR TITLE
Fix setup loop when already completed

### DIFF
--- a/src/app/api/setup/complete/handler.test.ts
+++ b/src/app/api/setup/complete/handler.test.ts
@@ -22,12 +22,13 @@ describe("setup complete handler", () => {
     expect((await response.json()).error).toBe("bad");
   });
 
-  it("maps alreadySetup to 409", async () => {
+  it("maps alreadySetup to 200", async () => {
     const response = await handleSetupComplete(makeRequest({}), {
       completeSetup: async () => ({ status: "alreadySetup" }),
       ...baseDeps,
     });
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
+    expect((await response.json()).alreadySetup).toBe(true);
   });
 
   it("maps ok to 200", async () => {

--- a/src/app/api/setup/complete/handler.ts
+++ b/src/app/api/setup/complete/handler.ts
@@ -65,7 +65,7 @@ export async function handleSetupComplete(
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
   if (result.status === "alreadySetup") {
-    return NextResponse.json({ error: "Setup already completed" }, { status: 409 });
+    return NextResponse.json({ ok: true, alreadySetup: true });
   }
   if (result.status === "dbError") {
     return NextResponse.json({ error: result.error }, { status: 503 });


### PR DESCRIPTION
## Summary\n- return ok when setup is already completed to avoid loop on step-4\n\n## Testing\n- npm test -- src/app/api/setup/complete/handler.test.ts\n