### PR TITLE
Fix login loop by deriving NEXTAUTH_URL

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,9 +5,9 @@ import { getAuthOptions } from "@/lib/auth";
 type RouteContext = { params: Promise<{ nextauth: string[] }> };
 
 export async function GET(request: NextRequest, context: RouteContext) {
-  return NextAuth(getAuthOptions())(request, context);
+  return NextAuth(getAuthOptions(request))(request, context);
 }
 
 export async function POST(request: NextRequest, context: RouteContext) {
-  return NextAuth(getAuthOptions())(request, context);
+  return NextAuth(getAuthOptions(request))(request, context);
 }

--- a/src/lib/__tests__/auth-options.test.ts
+++ b/src/lib/__tests__/auth-options.test.ts
@@ -23,4 +23,17 @@ describe("auth options", () => {
     const authOptions = await loadAuthOptions();
     expect(authOptions.useSecureCookies).toBe(true);
   });
+
+  it("derives NEXTAUTH_URL from request headers when env missing", async () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    const mod = await import("../auth");
+    const authOptions = mod.getAuthOptions({
+      headers: new Headers({
+        host: "10.10.1.236:3000",
+        "x-forwarded-proto": "http",
+      }),
+    });
+    expect(authOptions.useSecureCookies).toBe(false);
+    expect(process.env.NEXTAUTH_URL).toBe("http://10.10.1.236:3000");
+  });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,17 +1,42 @@
 import type { NextAuthOptions } from "next-auth";
+import type { NextRequest } from "next/server";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { compare } from "bcryptjs";
 import { getPrisma } from "./db";
 import { loadRuntimeConfig } from "./runtimeConfig";
 
-export function getAuthOptions(): NextAuthOptions {
-  loadRuntimeConfig();
+type RequestLike = Pick<NextRequest, "headers"> & { nextUrl?: URL };
 
-  const nextAuthUrl = process.env.NEXTAUTH_URL?.trim() ?? "";
+function resolveNextAuthUrl(request?: RequestLike) {
+  const envUrl = process.env.NEXTAUTH_URL?.trim();
+  if (envUrl) {
+    return envUrl;
+  }
+  if (request) {
+    const proto =
+      request.headers.get("x-forwarded-proto") ??
+      request.headers.get("x-forwarded-protocol") ??
+      request.nextUrl?.protocol?.replace(":", "") ??
+      "http";
+    const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+    if (host) {
+      return `${proto}://${host}`;
+    }
+  }
+  return "";
+}
+
+export function getAuthOptions(request?: RequestLike): NextAuthOptions {
+  loadRuntimeConfig();
+  const nextAuthUrl = resolveNextAuthUrl(request);
+  if (nextAuthUrl && !process.env.NEXTAUTH_URL) {
+    process.env.NEXTAUTH_URL = nextAuthUrl;
+  }
   const useSecureCookies = nextAuthUrl.startsWith("https://");
 
   return {
     useSecureCookies,
+    trustHost: true,
     providers: [
       CredentialsProvider({
         name: "Credentials",


### PR DESCRIPTION
## Summary\n- derive NEXTAUTH_URL from request headers when missing\n- enable trustHost to accept proxy host\n\n## Testing\n- npm test -- src/lib/__tests__/auth-options.test.ts\n