### PR TITLE
Fix build: remove unsupported trustHost

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -36,7 +36,6 @@ export function getAuthOptions(request?: RequestLike): NextAuthOptions {
 
   return {
     useSecureCookies,
-    trustHost: true,
     providers: [
       CredentialsProvider({
         name: "Credentials",


### PR DESCRIPTION
## Summary\n- remove unsupported trustHost option from NextAuth v4 config\n\n## Testing\n- npm test -- src/lib/__tests__/auth-options.test.ts\n