### PR TITLE
Fix login loop by using request origin

### DIFF
--- a/src/lib/__tests__/auth-options.test.ts
+++ b/src/lib/__tests__/auth-options.test.ts
@@ -24,7 +24,7 @@ describe("auth options", () => {
     expect(authOptions.useSecureCookies).toBe(true);
   });
 
-  it("derives NEXTAUTH_URL from request headers when env missing", async () => {
+  it("derives NEXTAUTH_URL from request origin when env missing", async () => {
     vi.stubEnv("NEXTAUTH_URL", "");
     const mod = await import("../auth");
     const authOptions = mod.getAuthOptions({
@@ -32,6 +32,7 @@ describe("auth options", () => {
         host: "10.10.1.236:3000",
         "x-forwarded-proto": "http",
       }),
+      nextUrl: new URL("http://10.10.1.236:3000/login"),
     });
     expect(authOptions.useSecureCookies).toBe(false);
     expect(process.env.NEXTAUTH_URL).toBe("http://10.10.1.236:3000");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,6 +13,10 @@ function resolveNextAuthUrl(request?: RequestLike) {
     return envUrl;
   }
   if (request) {
+    const origin = request.nextUrl?.origin;
+    if (origin) {
+      return origin;
+    }
     const proto =
       request.headers.get("x-forwarded-proto") ??
       request.headers.get("x-forwarded-protocol") ??


### PR DESCRIPTION
## Summary\n- derive NEXTAUTH_URL from request.origin before forwarded headers\n- prevents secure cookies on plain http\n\n## Testing\n- npm test -- src/lib/__tests__/auth-options.test.ts\n