### PR TITLE
fix: stabilize login callback and cookie detection

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -31,7 +31,10 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
   const proto = resolveRequestProto(request);
-  const token = await getToken({ req: request, secret, secureCookie: proto === "https" });
+  const preferSecure = proto === "https";
+  const token =
+    (await getToken({ req: request, secret, secureCookie: preferSecure })) ??
+    (await getToken({ req: request, secret, secureCookie: false }));
   const isAuthRoute =
     pathname.startsWith("/login") ||
     pathname.startsWith("/register") ||

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -67,4 +67,20 @@ describe("middleware", () => {
       expect.objectContaining({ secureCookie: false })
     );
   });
+
+  it("falls back to non-secure cookie when secure cookie is missing", async () => {
+    mockGetToken.mockResolvedValueOnce(null).mockResolvedValueOnce({ sub: "user-id" });
+    const response = await middleware(
+      makeRequest("/", { host: "10.10.1.236:3000", proto: "https" })
+    );
+    expect(mockGetToken).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ secureCookie: true })
+    );
+    expect(mockGetToken).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ secureCookie: false })
+    );
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { signIn } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { useSettings } from "@/components/desktop/SettingsProvider";
 import { handleLoginSuccessFlow } from "@/lib/authFlow";
+import { getAuthCallbackUrl } from "@/lib/authNavigation";
 import { getSetupRedirect } from "@/lib/setupRoutes";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { ICON_PATHS } from "@/lib/iconMap";
@@ -45,10 +46,14 @@ export default function LoginPage() {
     setError(null);
 
     try {
+      const callbackUrl = getAuthCallbackUrl(
+        typeof window !== "undefined" ? window.location.href : undefined
+      );
       const result = await signIn("credentials", {
         email,
         password,
         redirect: false,
+        callbackUrl,
       });
 
       if (result?.error) {

--- a/src/lib/__tests__/auth-navigation.test.ts
+++ b/src/lib/__tests__/auth-navigation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getAuthCallbackUrl } from "../authNavigation";
+
+describe("auth navigation", () => {
+  it("returns origin for valid current url", () => {
+    const result = getAuthCallbackUrl("http://10.10.1.236:3000/login?from=1");
+    expect(result).toBe("http://10.10.1.236:3000");
+  });
+
+  it("returns undefined for invalid url", () => {
+    const result = getAuthCallbackUrl("not a url");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/authNavigation.ts
+++ b/src/lib/authNavigation.ts
@@ -22,3 +22,14 @@ export function getLogoutRedirect(
     return fallback;
   }
 }
+
+export function getAuthCallbackUrl(currentUrl?: string) {
+  if (!currentUrl) {
+    return undefined;
+  }
+  try {
+    return new URL(currentUrl).origin;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Что сделано
- callbackUrl берётся из текущего origin на клиенте
- middleware пытается secure и non-secure cookie
- тесты для навигации и middleware

## Тесты
- npm test src/__tests__/middleware.test.ts src/lib/__tests__/auth-navigation.test.ts