### PR TITLE
fix: smb root listing

### DIFF
--- a/src/lib/__tests__/storage-paths.test.ts
+++ b/src/lib/__tests__/storage-paths.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { normalizeStorageSubPath } from "@/lib/storage/paths";
+import { buildRemotePath, normalizeStorageSubPath } from "@/lib/storage/paths";
 
 describe("storage subpath normalize", () => {
   it("keeps safe normalized path", () => {
     expect(normalizeStorageSubPath("media/videos")).toBe("media/videos");
+  });
+
+  it("maps video root to smb share root", () => {
+    expect(buildRemotePath("video", "")).toBe("\\");
   });
 });

--- a/src/lib/storage/paths.ts
+++ b/src/lib/storage/paths.ts
@@ -12,5 +12,6 @@ export function stripVideoPrefix(path: string) {
 
 export function buildRemotePath(path: string, subPath: string) {
   const tail = stripVideoPrefix(path);
-  return [subPath, tail].filter(Boolean).join("/");
+  const joined = [subPath, tail].filter(Boolean).join("/");
+  return joined || "\\";
 }


### PR DESCRIPTION
## Что исправлено
- Корректный путь к корню SMB при листинге video (\), чтобы список не зависал и файлы появлялись.

## Проверки
- npm test src/lib/__tests__/storage-paths.test.ts