### PR TITLE
fix: stabilize login redirect

### DIFF
--- a/src/app/__tests__/home-page.test.tsx
+++ b/src/app/__tests__/home-page.test.tsx
@@ -4,21 +4,27 @@ import { renderToString } from "react-dom/server";
 const getSetupStatus = vi.hoisted(() => vi.fn());
 const getSetupRedirect = vi.hoisted(() => vi.fn());
 const getServerSession = vi.hoisted(() => vi.fn());
+const getAuthOptions = vi.hoisted(() => vi.fn());
+const headers = vi.hoisted(() => vi.fn());
+const HEADER_TOKEN = { get: () => null };
 
 vi.mock("@/lib/setupStatus", () => ({ getSetupStatus }));
 vi.mock("@/lib/setupRoutes", () => ({ getSetupRedirect }));
 vi.mock("next-auth", () => ({ getServerSession }));
+vi.mock("next/headers", () => ({ headers }));
 vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
 vi.mock("@/components/desktop/DesktopClient", () => ({
   default: () => null,
 }));
-vi.mock("@/lib/auth", () => ({ getAuthOptions: () => ({}) }));
+vi.mock("@/lib/auth", () => ({ getAuthOptions }));
 
 describe("home page setup status", () => {
   it("requests auto-fix when checking setup status", async () => {
     getSetupStatus.mockResolvedValue("ready");
     getSetupRedirect.mockReturnValue(null);
     getServerSession.mockResolvedValue({ user: { email: "ops@local" } });
+    getAuthOptions.mockReturnValue({});
+    headers.mockReturnValue(HEADER_TOKEN);
 
     const { default: HomePage } = await import("../page");
     const element = await HomePage();
@@ -28,5 +34,20 @@ describe("home page setup status", () => {
       allowAutoDbFix: true,
       allowAutoSslFix: true,
     });
+  });
+
+  it("passes request headers to auth options", async () => {
+    getSetupStatus.mockResolvedValue("ready");
+    getSetupRedirect.mockReturnValue(null);
+    getServerSession.mockResolvedValue({ user: { email: "ops@local" } });
+    getAuthOptions.mockReturnValue({});
+    headers.mockReturnValue(HEADER_TOKEN);
+
+    const { default: HomePage } = await import("../page");
+    const element = await HomePage();
+    renderToString(element);
+
+    expect(headers).toHaveBeenCalled();
+    expect(getAuthOptions).toHaveBeenCalledWith({ headers: HEADER_TOKEN });
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { getServerSession } from "next-auth";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import DesktopClient from "@/components/desktop/DesktopClient";
 import { getAuthOptions } from "@/lib/auth";
@@ -22,7 +23,7 @@ export default async function HomePage() {
     );
   }
 
-  const session = await getServerSession(getAuthOptions());
+  const session = await getServerSession(getAuthOptions({ headers: headers() }));
   if (!session?.user) {
     redirect("/login");
   }


### PR DESCRIPTION
## Что сделано\n- На главной странице читаются request headers при сборе auth options, чтобы cookie совпадали с реальным origin\n- Добавлен тест, фиксирующий передачу headers\n\n## Проверки\n- npm test -- src/app/__tests__/home-page.test.tsx